### PR TITLE
removed time requirement fixes #5

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
-time
 ollama
 youtube-transcript-api


### PR DESCRIPTION
As per issue #5 seemingly time is not required and fails pip install -r requirements.txt