### PR TITLE
Specify major versions of dependencies for stability

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-ollama
-youtube-transcript-api
+ollama~=0.5
+youtube-transcript-api~=1.1


### PR DESCRIPTION
Specifies major versions for `ollama` and `youtube-transcript-api` to avoid breakage if future updates change functionality.

Note that the best practice in this event is probably updating the code to account for changes, then updating the requirements file. *Slightly* more work bc you have to remember to try new versions manually and update the requirements file, but gives a fallback so that this whole program doesn't break for the duration of fixes for new versions.